### PR TITLE
Add per-GPIO binary and mode objects

### DIFF
--- a/Bacnet-server.py
+++ b/Bacnet-server.py
@@ -5,7 +5,11 @@ import Adafruit_DHT.common as dht_common  # Fix per "Unknown platform"
 
 from bacpypes.core import run, stop
 from bacpypes.app import BIPSimpleApplication
-from bacpypes.object import BinaryInputObject, BinaryOutputObject, AnalogValueObject
+from bacpypes.object import (
+    AnalogValueObject,
+    BinaryValueObject,
+    MultiStateValueObject,
+)
 from bacpypes.local.device import LocalDeviceObject
 from bacpypes.task import RecurringTask
 from bacpypes.primitivedata import Unsigned
@@ -19,14 +23,18 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Configura i pin GPIO
-INPUT_PIN = 17
-OUTPUT_PIN = 27
+# Gestiamo tutti i pin disponibili tramite BCM
+GPIO_PINS = [
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+    14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+    24, 25, 26, 27,
+]
 DHT_PIN = 4  # pin GPIO per DHT11
 
 GPIO.setwarnings(False)
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(INPUT_PIN, GPIO.IN)
-GPIO.setup(OUTPUT_PIN, GPIO.OUT)
+for pin in GPIO_PINS:
+    GPIO.setup(pin, GPIO.IN)
 
 # Parametri del dispositivo BACnet
 DEVICE_ID = 110
@@ -53,28 +61,48 @@ device.databaseRevision = Unsigned(0)
 # Crea l'applicazione BACnet
 this_application = BIPSimpleApplication(device, '192.168.1.10/24:47808')
 
-# Binary Input
-bi = BinaryInputObject(
-    objectIdentifier=('binaryInput', 1),
-    objectName='GPIO_17_Input',
-    presentValue=0
-)
-this_application.add_object(bi)
-
-# Binary Output
-class CustomBinaryOutput(BinaryOutputObject):
+# Oggetti BinaryValue e MultiStateValue per ogni GPIO
+class CustomBinaryValue(BinaryValueObject):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.statusFlags = StatusFlags([False, False, False, False])
         self.outOfService = False
         self.eventState = 'normal'
 
-bo = CustomBinaryOutput(
-    objectIdentifier=('binaryOutput', 1),
-    objectName='GPIO_27_Output',
-    presentValue='inactive'
-)
-this_application.add_object(bo)
+
+class CustomMultiStateValue(MultiStateValueObject):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.statusFlags = StatusFlags([False, False, False, False])
+        self.outOfService = False
+        self.eventState = 'normal'
+
+
+gpio_bv_objects = {}
+gpio_mode_objects = {}
+
+bv_index = 1
+mv_index = 1
+for pin in GPIO_PINS:
+    bv = CustomBinaryValue(
+        objectIdentifier=('binaryValue', bv_index),
+        objectName=f'GPIO_{pin}_BV',
+        presentValue='inactive',
+    )
+    this_application.add_object(bv)
+    gpio_bv_objects[pin] = bv
+    bv_index += 1
+
+    mv = CustomMultiStateValue(
+        objectIdentifier=('multiStateValue', mv_index),
+        objectName=f'GPIO_{pin}_Mode',
+        presentValue=1,
+    )
+    mv.numberOfStates = 2
+    mv.stateText = ['Lettura', 'Lettura/Scrittura']
+    this_application.add_object(mv)
+    gpio_mode_objects[pin] = mv
+    mv_index += 1
 
 # Analog Value
 class CustomAnalogValue(AnalogValueObject):
@@ -95,16 +123,28 @@ this_application.add_object(av)
 class GPIOUpdateTask(RecurringTask):
     def __init__(self, interval):
         RecurringTask.__init__(self, interval * 1000)
+        self.pin_modes = {pin: GPIO.IN for pin in GPIO_PINS}
         self.install_task()
 
     def process_task(self):
-        # Leggi lo stato del Binary Input
-        value = GPIO.input(INPUT_PIN)
-        bi.presentValue = 1 if value else 0
-
-        # Scrivi lo stato del Binary Output
-        output_value = 1 if bo.presentValue == 'active' else 0
-        GPIO.output(OUTPUT_PIN, output_value)
+        for pin in GPIO_PINS:
+            mode = gpio_mode_objects[pin].presentValue
+            if mode == 1:
+                if self.pin_modes[pin] != GPIO.IN:
+                    GPIO.setup(pin, GPIO.IN)
+                    self.pin_modes[pin] = GPIO.IN
+                val = GPIO.input(pin)
+                gpio_bv_objects[pin].presentValue = (
+                    'active' if val else 'inactive'
+                )
+            else:
+                if self.pin_modes[pin] != GPIO.OUT:
+                    GPIO.setup(pin, GPIO.OUT)
+                    self.pin_modes[pin] = GPIO.OUT
+                output_value = (
+                    1 if gpio_bv_objects[pin].presentValue == 'active' else 0
+                )
+                GPIO.output(pin, output_value)
 
         # Leggi la temperatura dal DHT11 e aggiorna l'AnalogValue
         humidity, temperature = Adafruit_DHT.read_retry(Adafruit_DHT.DHT11, DHT_PIN)


### PR DESCRIPTION
## Summary
- manage all BCM GPIOs
- create binary value and multi-state value BACnet objects for each GPIO with the same alarm/event properties as the original BO
- update task to read or write each pin based on its multi-state value

## Testing
- `python -m py_compile Bacnet-server.py`

------
https://chatgpt.com/codex/tasks/task_e_68498f0e71448330a14f8cef5d4a9791