### PR TITLE
Add dynamic BACnet object loading

### DIFF
--- a/Bacnet-server.py
+++ b/Bacnet-server.py
@@ -1,4 +1,6 @@
 import logging
+import json
+import importlib
 import RPi.GPIO as GPIO
 import Adafruit_DHT
 import Adafruit_DHT.common as dht_common  # Fix per "Unknown platform"
@@ -53,6 +55,46 @@ device.databaseRevision = Unsigned(0)
 # Crea l'applicazione BACnet
 this_application = BIPSimpleApplication(device, '192.168.1.10/24:47808')
 
+# ------------------------------------------------------------------------------
+# Helper per aggiungere dinamicamente oggetti BACnet
+# ------------------------------------------------------------------------------
+
+def add_object(module_path, class_name, params):
+    """Importa dinamicamente e aggiunge un oggetto BACnet all'applicazione."""
+    try:
+        module = importlib.import_module(module_path)
+        cls = getattr(module, class_name)
+    except (ImportError, AttributeError) as err:
+        logger.error("Impossibile caricare %s.%s: %s", module_path, class_name, err)
+        return None
+
+    obj = cls(**params)
+    this_application.add_object(obj)
+    logger.info("Oggetto aggiunto: %s (%s)", params.get("objectName"), class_name)
+    return obj
+
+
+def load_objects_from_config(config_path="objects.json"):
+    """Carica oggetti aggiuntivi da un file JSON."""
+    try:
+        with open(config_path) as cfg:
+            objects = json.load(cfg)
+    except FileNotFoundError:
+        logger.warning("File di configurazione %s non trovato", config_path)
+        return
+    except json.JSONDecodeError as err:
+        logger.error("Errore di parsing %s: %s", config_path, err)
+        return
+
+    for entry in objects:
+        module_path = entry.get("module")
+        class_name = entry.get("class")
+        params = entry.get("params", {})
+        if not module_path or not class_name:
+            logger.warning("Definizione oggetto non valida: %s", entry)
+            continue
+        add_object(module_path, class_name, params)
+
 # Binary Input
 bi = BinaryInputObject(
     objectIdentifier=('binaryInput', 1),
@@ -90,6 +132,9 @@ av = CustomAnalogValue(
     presentValue=0.0
 )
 this_application.add_object(av)
+
+# Carica eventuali oggetti aggiuntivi definiti in objects.json
+load_objects_from_config()
 
 # Task GPIO e DHT11
 class GPIOUpdateTask(RecurringTask):

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# BACnet Pi Server
+
+Questo server BACnet per Raspberry Pi consente di esporre punti come input e output GPIO.
+
+## Aggiunta di oggetti dinamici
+
+Oltre agli oggetti predefiniti (Binary Input, Binary Output e Analog Value) è possibile
+aggiungere ulteriori oggetti definendoli in un file `objects.json` posizionato nella stessa
+cartella dello script.
+
+Il file deve contenere una lista di oggetti con i seguenti campi:
+
+```json
+[
+  {
+    "module": "bacpypes.object",
+    "class": "BinaryInputObject",
+    "params": {
+      "objectIdentifier": ["binaryInput", 2],
+      "objectName": "EsempioBI",
+      "presentValue": 0
+    }
+  }
+]
+```
+
+Il sistema importa dinamicamente il modulo e la classe indicati e aggiunge l'oggetto
+all'applicazione. In questo modo è possibile utilizzare qualsiasi tipo di oggetto fornito
+ dalle librerie installate, inclusi quelli elencati nella richiesta (Alarm, Schedule, ecc.).
+
+## Esecuzione
+
+Assicurarsi che le dipendenze (RPi.GPIO, Adafruit_DHT, bacpypes) siano installate.
+Avviare lo script con:
+
+```bash
+python Bacnet-server.py
+```

--- a/objects.json
+++ b/objects.json
@@ -1,0 +1,12 @@
+[
+  {
+    "module": "bacpypes.object",
+    "class": "BinaryInputObject",
+    "params": {
+      "objectIdentifier": ["binaryInput", 2],
+      "objectName": "ExampleInput",
+      "presentValue": 0
+    }
+  }
+]
+


### PR DESCRIPTION
## Summary
- allow BACnet objects to be added dynamically from `objects.json`
- provide helper functions to load any available object types
- add example config and usage instructions in README

## Testing
- `python -m py_compile Bacnet-server.py`

------
https://chatgpt.com/codex/tasks/task_e_68499603db10833081f767e2ee215fd7