### PR TITLE
Remove DHT11 and add multistate object

### DIFF
--- a/Bacnet-server.py
+++ b/Bacnet-server.py
@@ -2,33 +2,35 @@ import logging
 import json
 import importlib
 import RPi.GPIO as GPIO
-import Adafruit_DHT
-import Adafruit_DHT.common as dht_common  # Fix per "Unknown platform"
+
 
 from bacpypes.core import run, stop
 from bacpypes.app import BIPSimpleApplication
-from bacpypes.object import BinaryInputObject, BinaryOutputObject, AnalogValueObject
+from bacpypes.object import (
+    BinaryInputObject,
+    BinaryOutputObject,
+    MultiStateValueObject,
+)
 from bacpypes.local.device import LocalDeviceObject
 from bacpypes.task import RecurringTask
 from bacpypes.primitivedata import Unsigned
 from bacpypes.basetypes import StatusFlags
 
-# Forza la piattaforma a 'Raspberry Pi'
-dht_common.get_platform = lambda: 'Raspberry Pi'
 
 # Configura logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Configura i pin GPIO
-INPUT_PIN = 17
-OUTPUT_PIN = 27
-DHT_PIN = 4  # pin GPIO per DHT11
+INPUT_PINS = [17]
+OUTPUT_PINS = [27]
 
 GPIO.setwarnings(False)
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(INPUT_PIN, GPIO.IN)
-GPIO.setup(OUTPUT_PIN, GPIO.OUT)
+for pin in INPUT_PINS:
+    GPIO.setup(pin, GPIO.IN)
+for pin in OUTPUT_PINS:
+    GPIO.setup(pin, GPIO.OUT)
 
 # Parametri del dispositivo BACnet
 DEVICE_ID = 110
@@ -68,7 +70,6 @@ def add_object(module_path, class_name, params):
         logger.error("Impossibile caricare %s.%s: %s", module_path, class_name, err)
         return None
 
-main
     obj = cls(**params)
     this_application.add_object(obj)
     logger.info("Oggetto aggiunto: %s (%s)", params.get("objectName"), class_name)
@@ -96,15 +97,10 @@ def load_objects_from_config(config_path="objects.json"):
             continue
         add_object(module_path, class_name, params)
 
-# Binary Input
-bi = BinaryInputObject(
-    objectIdentifier=('binaryInput', 1),
-    objectName='GPIO_17_Input',
-    presentValue=0
-)
-this_application.add_object(bi)
+# Binary Input/Output Objects for GPIO
+binary_inputs = {}
+binary_outputs = {}
 
-# Binary Output
 class CustomBinaryOutput(BinaryOutputObject):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -112,52 +108,60 @@ class CustomBinaryOutput(BinaryOutputObject):
         self.outOfService = False
         self.eventState = 'normal'
 
-bo = CustomBinaryOutput(
-    objectIdentifier=('binaryOutput', 1),
-    objectName='GPIO_27_Output',
-    presentValue='inactive'
-)
-this_application.add_object(bo)
+for idx, pin in enumerate(INPUT_PINS, start=1):
+    bi = BinaryInputObject(
+        objectIdentifier=('binaryInput', idx),
+        objectName=f'GPIO_{pin}_Input',
+        presentValue=0,
+    )
+    this_application.add_object(bi)
+    binary_inputs[pin] = bi
 
-# Analog Value
-class CustomAnalogValue(AnalogValueObject):
+for idx, pin in enumerate(OUTPUT_PINS, start=1):
+    bo = CustomBinaryOutput(
+        objectIdentifier=('binaryOutput', idx),
+        objectName=f'GPIO_{pin}_Output',
+        presentValue='inactive',
+    )
+    this_application.add_object(bo)
+    binary_outputs[pin] = bo
+
+# Multi-State Value
+class CustomMultiStateValue(MultiStateValueObject):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.statusFlags = StatusFlags([False, False, False, False])
         self.outOfService = False
         self.eventState = 'normal'
 
-av = CustomAnalogValue(
-    objectIdentifier=('analogValue', 1),
-    objectName='Temperature_AV',
-    presentValue=0.0
+msv = CustomMultiStateValue(
+    objectIdentifier=('multiStateValue', 1),
+    objectName='Operation_Mode',
+    presentValue=1,
+    numberOfStates=3,
+    stateText=["Off", "Manual", "Automatic"],
 )
-this_application.add_object(av)
+this_application.add_object(msv)
+
 
 # Carica eventuali oggetti aggiuntivi definiti in objects.json
 load_objects_from_config()
 
-# Task GPIO e DHT11
+# Task GPIO
 class GPIOUpdateTask(RecurringTask):
     def __init__(self, interval):
         RecurringTask.__init__(self, interval * 1000)
         self.install_task()
 
     def process_task(self):
-        # Leggi lo stato del Binary Input
-        value = GPIO.input(INPUT_PIN)
-        bi.presentValue = 1 if value else 0
+        # Aggiorna tutti i Binary Input
+        for pin, obj in binary_inputs.items():
+            obj.presentValue = 1 if GPIO.input(pin) else 0
 
-        # Scrivi lo stato del Binary Output
-        output_value = 1 if bo.presentValue == 'active' else 0
-        GPIO.output(OUTPUT_PIN, output_value)
-
-        # Leggi la temperatura dal DHT11 e aggiorna l'AnalogValue
-        humidity, temperature = Adafruit_DHT.read_retry(Adafruit_DHT.DHT11, DHT_PIN)
-        if temperature is not None:
-            av.presentValue = float(temperature)
-        else:
-            av.presentValue = 0.0  # fallback
+        # Aggiorna tutti i Binary Output
+        for pin, obj in binary_outputs.items():
+            value = 1 if obj.presentValue == 'active' else 0
+            GPIO.output(pin, value)
 
         self.install_task()
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Questo server BACnet per Raspberry Pi consente di esporre punti come input e out
 
 ## Aggiunta di oggetti dinamici
 
-Oltre agli oggetti predefiniti (Binary Input, Binary Output e Analog Value) è possibile
+Oltre agli oggetti predefiniti (Binary Input, Binary Output e Multi-State Value) è possibile
 aggiungere ulteriori oggetti definendoli in un file `objects.json` posizionato nella stessa
 cartella dello script.
 
@@ -30,7 +30,7 @@ all'applicazione. In questo modo è possibile utilizzare qualsiasi tipo di ogget
 
 ## Esecuzione
 
-Assicurarsi che le dipendenze (RPi.GPIO, Adafruit_DHT, bacpypes) siano installate.
+Assicurarsi che le dipendenze (RPi.GPIO e bacpypes) siano installate.
 Avviare lo script con:
 
 ```bash


### PR DESCRIPTION
## Summary
- remove DHT11 logic and analog value object
- create binary input/output objects for each GPIO
- add a sample multi-state value object
- keep ability to load custom objects from `objects.json`
- update README accordingly

## Testing
- `python -m py_compile Bacnet-server.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b4ee94dc83308ed8026621c86609