### PR TITLE
Handle objectIdentifier lists in config

### DIFF
--- a/Bacnet-server.py
+++ b/Bacnet-server.py
@@ -70,6 +70,11 @@ def add_object(module_path, class_name, params):
         logger.error("Impossibile caricare %s.%s: %s", module_path, class_name, err)
         return None
 
+    # Converte l'objectIdentifier da lista a tupla se necessario
+    oid = params.get("objectIdentifier")
+    if isinstance(oid, list):
+        params["objectIdentifier"] = tuple(oid)
+
     obj = cls(**params)
     this_application.add_object(obj)
     logger.info("Oggetto aggiunto: %s (%s)", params.get("objectName"), class_name)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Il file deve contenere una lista di oggetti con i seguenti campi:
 
 Il sistema importa dinamicamente il modulo e la classe indicati e aggiunge l'oggetto
 all'applicazione. In questo modo è possibile utilizzare qualsiasi tipo di oggetto fornito
- dalle librerie installate, inclusi quelli elencati nella richiesta (Alarm, Schedule, ecc.).
+dalle librerie installate, inclusi quelli elencati nella richiesta (Alarm, Schedule, ecc.).
+Se nel file JSON `objectIdentifier` è definito come lista, lo script lo converte
+automaticamente in una tupla prima di creare l'oggetto.
 
 ## Esecuzione
 


### PR DESCRIPTION
## Summary
- cast `objectIdentifier` lists to tuples when creating dynamic objects
- document automatic conversion in README

## Testing
- `python -m py_compile Bacnet-server.py`
- *(fails: ModuleNotFoundError: No module named 'RPi' when running server)*

------
https://chatgpt.com/codex/tasks/task_e_6849bf5616dc8330a4ac23ce72d2da60