### PR TITLE
Fix polarity property error

### DIFF
--- a/Bacnet-server.py
+++ b/Bacnet-server.py
@@ -158,7 +158,9 @@ class CustomBinaryOutput(BinaryOutputObject):
         self.statusFlags = StatusFlags([False, False, False, False])
         self.outOfService = False
         self.eventState = 'normal'
-        self.polarity = Polarity('normal')
+        # store the polarity as a string so that bacpypes can
+        # convert it correctly when the property is read
+        self.polarity = 'normal'
 
 
 # Task GPIO
@@ -175,7 +177,7 @@ class GPIOUpdateTask(RecurringTask):
         # Aggiorna tutti i Binary Output
         for pin, obj in binary_outputs.items():
             value = 1 if obj.presentValue == 'active' else 0
-            if getattr(obj, 'polarity', Polarity('normal')) == Polarity('reverse'):
+            if Polarity(getattr(obj, 'polarity', 'normal')) == Polarity('reverse'):
                 value = 0 if value == 1 else 1
             GPIO.output(pin, value)
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ proprietà `protocolObjectTypesSupported` del dispositivo. Tutti i pin BCM
 pari (2–27) vengono configurati come *Binary Input*, mentre i pin dispari
 diventano *Binary Output* controllabili tramite la proprietà
 `presentValue`. Ogni oggetto viene chiamato `GPIOX`, dove `X` è il numero
-codex/rendere-la-proprietà-polarità-scrivibile
- del pin, e possiede come descrizione `GPIOX Pin X`. Per i Binary Output
- è ora possibile modificare anche la proprietà `polarity` per invertire
- il comportamento di attivazione.
+del pin e possiede come descrizione `GPIOX Pin X`. Per i *Binary Output*
+è disponibile anche la proprietà `polarity` (valori `normal` o `reverse`)
+che consente di invertire il comportamento di attivazione.
 
 ## Aggiunta di oggetti dinamici
 


### PR DESCRIPTION
## Summary
- fix polarity initialization for Binary Outputs
- clarify polarity usage in README

## Testing
- `python -m py_compile Bacnet-server.py`

------
https://chatgpt.com/codex/tasks/task_e_684d9baf861883308eeb63371b60a578