### PR TITLE
Fix quoting in systemd ExecStart

### DIFF
--- a/install_service.py
+++ b/install_service.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 
@@ -21,7 +22,11 @@ def build_exec_command(args, server_path):
         cmd += ["--broadcast-ip", args.broadcast_ip]
     if args.device_id is not None:
         cmd += ["--device-id", str(args.device_id)]
-    return " ".join(cmd)
+    # Quote each argument because ExecStart is parsed without a shell and
+    # any spaces would otherwise split arguments
+    if hasattr(shlex, "join"):
+        return shlex.join(cmd)
+    return " ".join(shlex.quote(part) for part in cmd)
 
 
 def write_service_file(path, working_dir, exec_cmd):


### PR DESCRIPTION
## Summary
- ensure install_service escapes ExecStart arguments using shlex
- add a short comment explaining the quoting

## Testing
- `python3 -m py_compile install_service.py`
- `python3 install_service.py --help | head -n 20`
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e92f9f5b08330864901661cf5df9d