### PR TITLE
Add troubleshooting documentation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,3 +53,37 @@ startup fails `BACnet_Pi_Server fallito avviamento` is shown.
 
 The current version is stored in the `VERSION` file. Each code change should bump the version by **0.0.1** so that the `applicationSoftwareVersion` and `firmwareRevision` properties remain aligned.
 
+## Troubleshooting
+
+When the server does not respond as expected try these checks.
+
+- Verify the systemd service status:
+
+```bash
+sudo systemctl status bacnet.service
+```
+
+- Confirm UDP port 47808 is listening:
+
+```bash
+sudo ss -lun | grep 47808
+```
+
+- Capture network traffic to inspect BACnet packets:
+
+```bash
+sudo tcpdump -i eth0 udp port 47808
+```
+
+- When working across subnets register to a BBMD:
+
+```bash
+./Bacnet-server.py --bbmd 192.168.0.10
+```
+
+- Adjust the broadcast address if needed:
+
+```bash
+./Bacnet-server.py --broadcast-ip 255.255.255.255
+```
+

--- a/README.md
+++ b/README.md
@@ -123,3 +123,37 @@ Il numero di versione è contenuto nel file `VERSION`. Ogni modifica al codice
 deve incrementare la versione di **0.0.1** per mantenere allineate le
 proprietà `applicationSoftwareVersion` e `firmwareRevision` esposte dal
 dispositivo BACnet.
+
+## Risoluzione dei problemi
+
+Se il server non risponde correttamente eseguire i seguenti controlli.
+
+- Verificare lo stato del servizio systemd:
+
+```bash
+sudo systemctl status bacnet.service
+```
+
+- Controllare che la porta UDP 47808 sia in ascolto:
+
+```bash
+sudo ss -lun | grep 47808
+```
+
+- Analizzare il traffico di rete con `tcpdump`:
+
+```bash
+sudo tcpdump -i eth0 udp port 47808
+```
+
+- Su sottoreti differenti registrarsi a un BBMD:
+
+```bash
+./Bacnet-server.py --bbmd 192.168.0.10
+```
+
+- Se i broadcast non raggiungono i client modificare l'indirizzo:
+
+```bash
+./Bacnet-server.py --broadcast-ip 255.255.255.255
+```


### PR DESCRIPTION
## Summary
- document steps for checking BACnet server issues
- include service status and UDP port checks
- mention tcpdump and BBMD usage
- explain adjusting broadcast IP

## Testing
- `pytest -q`
- `python3 -m py_compile Bacnet-server.py install_service.py`


------
https://chatgpt.com/codex/tasks/task_e_687e930641648330b0bdb84d6678643c