### PR TITLE
Add CI workflow and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+      - name: Run smoke test
+        run: |
+          python -m unittest discover -s tests

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,19 @@
+import importlib.util
+import argparse
+import os
+import unittest
+
+from install_service import build_exec_command
+
+class SmokeTest(unittest.TestCase):
+    def test_import_and_build_exec(self):
+        module_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "Bacnet-server.py")
+        spec = importlib.util.spec_from_file_location("bacnet_server", module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        args = argparse.Namespace(address=None, config=None, bbmd=None, broadcast_ip=None, device_id=None)
+        cmd = build_exec_command(args, module_path)
+        self.assertIsInstance(cmd, str)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to install dependencies and run tests
- add a simple smoke test that imports the server and build_exec_command

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_687e930949288330b5d175f0b3674843